### PR TITLE
Fix reading values of the object type that declares no fields

### DIFF
--- a/sdk-v2/field_reader_diff.go
+++ b/sdk-v2/field_reader_diff.go
@@ -287,6 +287,16 @@ func (r *DiffFieldReader) readObjectField(
 		containsComputedValues = containsComputedValues || fieldContainsComputedValues
 	}
 
+	// In the rare case when the schema is an empty object, the default logic would return false here for Exists,
+	// but that triggers !rawResult.Exists check commented as "This should never happen" under readListField. What
+	// actually happens then is that instead of an empty object a nil value is read from the DiffFieldReader. This
+	// is unexpected. Instead, return the empty map and Exists: true in this case.
+	//
+	// See also pulumi/pulumi-aws#1423
+	if len(sch) == 0 {
+		exists = true
+	}
+
 	return schema.FieldReadResult{
 		Value:  result,
 		Exists: exists,

--- a/sdk-v2/field_reader_diff_test.go
+++ b/sdk-v2/field_reader_diff_test.go
@@ -1,0 +1,52 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sdkv2
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReadListOfObjectWithoutFields(t *testing.T) {
+	//attrs :=
+	sch := map[string]*schema.Schema{
+		"x": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{},
+			},
+		},
+	}
+	dfr := DiffFieldReader{
+		Source: &schema.MapFieldReader{
+			Schema: sch,
+			Map:    schema.BasicMapReader(map[string]string{}),
+		},
+		Diff: &terraform.InstanceDiff{
+			Attributes: map[string]*terraform.ResourceAttrDiff{
+				"x.#": {New: "1"},
+			},
+		},
+		Schema: sch,
+	}
+	res, err := dfr.ReadField([]string{"x"})
+	assert.NoError(t, err)
+	assert.Equal(t, []interface{}{map[string]interface{}{}}, res.Value)
+}

--- a/sdk-v2/field_reader_diff_test.go
+++ b/sdk-v2/field_reader_diff_test.go
@@ -24,7 +24,6 @@ import (
 )
 
 func TestReadListOfObjectWithoutFields(t *testing.T) {
-	//attrs :=
 	sch := map[string]*schema.Schema{
 		"x": {
 			Type:     schema.TypeList,


### PR DESCRIPTION
This surgical change helps pulumi-terraform-bridge to work around pulumi/pulumi-aws#1423

It is scoped to the rare case of an object type that does not declare any fields.

The affected path has this code which suggests it possibly should have been a panic, definitely should not happen:

```
		if !rawResult.Exists {
			// This should never happen, because by the time the data
			// gets to the FieldReaders, all the defaults should be set by
			// Schema.
			rawResult.Value = nil
		}
```

The condition probably does not arise in TF CLI as it does not pass the same inputs to FieldReadResult as the bridge does (see https://github.com/hashicorp/terraform-plugin-sdk/blob/6168812658d083acd6b929554d4e298cbbb81357/helper/schema/field_reader.go#L229 having the same logic as the base branch here), so there root cause fix is probably elsewhere; but modifying the diff logic runs into other difficulties and potentially breaking changes. One approach that was attempted is https://github.com/pulumi/pulumi-terraform-bridge/pull/887 

